### PR TITLE
fix: solhint fix warnings

### DIFF
--- a/slither.config.json
+++ b/slither.config.json
@@ -1,8 +1,10 @@
 {
   "filter_paths": "lib|src/base|test|src/dependencies/openzeppelin|src/upgradeability",
+  "detectors_to_exclude": "solc-version,naming-convention",
   "solc_remaps": [
     "ds-test/=lib/ds-test/src/",
     "forge-std/=lib/forge-std/src/",
+    "openzeppelin-contracts/=lib/openzeppelin-contracts/",
     "solmate/=lib/solmate/src/"
   ]
 }

--- a/src/BoxNFT.sol
+++ b/src/BoxNFT.sol
@@ -18,7 +18,7 @@ contract BoxNFT is CyberNFTBase, Auth, IBoxNFT {
         Auth.__Auth_Init(_owner, _rolesAuthority);
     }
 
-    function mint(address _to) public requiresAuth {
+    function mint(address _to) external requiresAuth {
         super._mint(_to);
     }
 


### PR DESCRIPTION
- functions that are used only externally should be declared external (saves gas)
- add openzeppelin remapping to slither config