### PR TITLE
ci: secure codecov uploads (oidc) and refresh action runtimes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,12 @@ jobs:
 
     name: Foundry project
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -30,12 +34,12 @@ jobs:
           forge test -vvv --gas-report
         id: test
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 20
 
       - name: Install modules
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Run lint
         run: yarn run lint:gh-check
@@ -44,9 +48,9 @@ jobs:
         run: forge coverage --report lcov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
-          token: 5988e766-42d2-43ef-813c-56f5b7cbcc6d
+          use_oidc: true
           directory: .
           env_vars: OS,PYTHON
           fail_ci_if_error: true


### PR DESCRIPTION
## what changed

The workflow checked a **Codecov upload token into the repository**. That credential is sensitive: it authorizes coverage uploads to your Codecov project and should never live in source control.

This update:

- **Removes the hardcoded token** and switches uploads to **OIDC** (`use_oidc: true` on `codecov/codecov-action@v5`), which is the recommended way to authenticate uploads without storing secrets in the repo. See [Codecov action readme](https://github.com/codecov/codecov-action#using-oidc).
- Bumps **actions/checkout** to v4 and **actions/setup-node** to v4 with **Node 20** (Node 14 is end-of-life).
- Uses **yarn install --frozen-lockfile** so CI matches **yarn.lock** exactly.

## maintainer follow-up (important)

Because the token was already public in git history, you should **rotate/revoke that upload token** in the Codecov project settings even after merge, and rely on OIDC (or a CODECOV_TOKEN secret) going forward.

If OIDC upload fails until Codecov is configured for the repo, confirm the Codecov GitHub app / OIDC integration is enabled for cyberconnecthq/cybercontracts.

---

made by mooncitydev